### PR TITLE
Extend feature set with pincode/DOB signals and Gmail email normalisation

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -32,7 +32,7 @@ def topk_by_vector(conn, query_vec, k):
     SELECT c.customer_id,
            VECTOR_DISTANCE(c.identity_vec, q.qvec) AS vdist,
            c.full_name, c.dob, c.phone_e164, c.email_norm, c.gov_id_norm,
-           c.addr_line, c.city, c.state
+           c.addr_line, c.city, c.state, c.postal_code
     FROM customers c CROSS JOIN q
     ORDER BY vdist
     FETCH FIRST :k ROWS ONLY

--- a/app/deduper.py
+++ b/app/deduper.py
@@ -31,6 +31,7 @@ def candidate_dict(row):
         "addr_line": row[7],
         "city": row[8],
         "state": row[9],
+        "postal_code": row[10],
     }
 
 def check_duplicate(payload):

--- a/app/features.py
+++ b/app/features.py
@@ -28,6 +28,31 @@ def addr_overlap(a, b):
         return 0.0
     return len(set_a & set_b) / len(set_a | set_b)
 
+
+def pincode_match(a, b):
+    """Exact match gives 1.0; first five digits match gives 0.5."""
+    a = (a or "").strip()
+    b = (b or "").strip()
+    if not a or not b:
+        return 0.0
+    if a == b:
+        return 1.0
+    if len(a) == 6 and len(b) == 6 and a[:5] == b[:5]:
+        return 0.5
+    return 0.0
+
+
+def dob_delta_days(a, b):
+    """Absolute difference in days between two ISO date strings."""
+    if not a or not b:
+        return 9999.0
+    from datetime import date
+    def to_date(x):
+        return x if isinstance(x, date) else date.fromisoformat(x)
+    da = to_date(a)
+    db = to_date(b)
+    return abs((da - db).days)
+
 def feature_row(query, candidate, vdist):
     """Generate feature vector for ranking."""
     vsim = 1.0 / (1.0 + vdist)  # distance to similarity-ish
@@ -40,4 +65,6 @@ def feature_row(query, candidate, vdist):
         addr_overlap(query.get("addr_line"), candidate.get("addr_line")),
         jw(query.get("city"), candidate.get("city")),
         jw(query.get("state"), candidate.get("state")),
+        pincode_match(query.get("postal_code"), candidate.get("postal_code")),
+        dob_delta_days(query.get("dob"), candidate.get("dob")),
     ]

--- a/app/normalization.py
+++ b/app/normalization.py
@@ -8,7 +8,20 @@ def norm_name(s: str) -> str:
     return s
 
 def norm_email(s: str) -> str:
-    return (s or "").strip().lower()
+    """Lowercase and apply provider-specific normalisation rules.
+
+    For Gmail/Googlemail addresses, dots in the local part are ignored and
+    anything after a plus sign is stripped.  Other providers simply get
+    lowercased and trimmed.
+    """
+    s = (s or "").strip().lower()
+    if not s:
+        return ""
+    local, sep, domain = s.partition("@")
+    if domain in ("gmail.com", "googlemail.com"):
+        local = local.split("+")[0]
+        local = local.replace(".", "")
+    return f"{local}{sep}{domain}"
 
 def norm_phone_e164(s: str) -> str:
     # Expect inputs like "+91..." or "91..." etc; normalize to +CC format where you can.

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,46 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.features import pincode_match, dob_delta_days, feature_row
+
+
+def test_pincode_match():
+    assert pincode_match('560001', '560001') == 1.0
+    assert pincode_match('560001', '560002') == 0.5
+    assert pincode_match('560001', '560101') == 0.0
+
+
+def test_dob_delta_days():
+    assert dob_delta_days('1990-01-01', '1990-01-01') == 0
+    assert dob_delta_days('1990-01-01', '1990-01-03') == 2
+    assert dob_delta_days(None, '1990-01-03') == 9999.0
+
+
+def test_feature_row_length_and_values():
+    q = {
+        'full_name': 'Alice Doe',
+        'dob': '1990-01-01',
+        'phone_e164': '+911234567890',
+        'email_norm': 'alice@example.com',
+        'gov_id_norm': 'PAN123',
+        'addr_line': '123 Main St',
+        'city': 'Bangalore',
+        'state': 'KA',
+        'postal_code': '560001',
+    }
+    c = {
+        'full_name': 'Alice Doe',
+        'dob': '1990-01-01',
+        'phone_e164': '+911234567890',
+        'email_norm': 'alice@example.com',
+        'gov_id_norm': 'PAN123',
+        'addr_line': '123 Main St',
+        'city': 'Bangalore',
+        'state': 'KA',
+        'postal_code': '560001',
+    }
+    feats = feature_row(q, c, 0.0)
+    assert len(feats) == 10
+    assert feats[-2] == 1.0  # pincode match
+    assert feats[-1] == 0.0  # dob delta

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,13 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.normalization import norm_email
+
+
+def test_norm_email_gmail_plus_dot():
+    assert norm_email('Foo.Bar+spam@gmail.com') == 'foobar@gmail.com'
+
+
+def test_norm_email_other_provider():
+    assert norm_email('User+spam@example.com') == 'user+spam@example.com'

--- a/training/train_ranker.py
+++ b/training/train_ranker.py
@@ -20,7 +20,7 @@ def fetch_candidate_row(conn, customer_id, qvec):
     WITH q AS (SELECT qvec FROM query_identity WHERE qid = :qid)
     SELECT c.customer_id, VECTOR_DISTANCE(c.identity_vec, q.qvec) AS vdist,
            c.full_name, c.dob, c.phone_e164, c.email_norm, c.gov_id_norm,
-           c.addr_line, c.city, c.state
+           c.addr_line, c.city, c.state, c.postal_code
     FROM customers c, q
     WHERE c.customer_id = :cid
     """


### PR DESCRIPTION
## Summary
- Normalise Gmail addresses by dropping dots and plus tags
- Add pincode match and DOB delta features to the ranker
- Surface postal codes in DB queries and candidate objects
- Exercise new logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fbd8608883309579a61054345ae7