### PR TITLE
Improve vector handling and default model

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -7,13 +7,31 @@ def get_conn():
     return oracledb.connect(user=Config.ORACLE_USER, password=Config.ORACLE_PASSWORD, dsn=Config.ORACLE_DSN)
 
 def to_vec_array(vec_f32):
+    """Convert an iterable of float32 values to :class:`array.array`.
+
+    Oracle 23ai's driver can error (``DPY-3002``) when numpy arrays are
+    bound directly.  Converting to ``array('f', ...)`` avoids this but we
+    also validate the length so that mismatched embeddings are caught
+    early.
+
+    Parameters
+    ----------
+    vec_f32: iterable
+        Sequence of float32 values representing an embedding.
+
+    Returns
+    -------
+    array.array
+        Array of type ``'f'`` with length equal to ``Config.VECTOR_DIM``.
+
+    Raises
+    ------
+    ValueError
+        If ``vec_f32`` does not have ``Config.VECTOR_DIM`` elements.
     """
-    Oracle 23ai Free often fails if you bind numpy arrays directly.
-    Convert to array('f', ...) to avoid DPY-3002.
-    Ensure len == VECTOR_DIM.
-    """
-    a = array.array('f', vec_f32)  # float32
-    return a
+    if len(vec_f32) != Config.VECTOR_DIM:
+        raise ValueError(f"expected vector of length {Config.VECTOR_DIM}")
+    return array.array('f', vec_f32)  # float32
 
 def topk_by_vector(conn, query_vec, k):
     """

--- a/app/model_store.py
+++ b/app/model_store.py
@@ -1,16 +1,34 @@
 import os, pickle
-from sklearn.linear_model import LogisticRegression
 import numpy as np
+from sklearn.dummy import DummyClassifier
 
-DEFAULT = LogisticRegression(max_iter=1000, class_weight="balanced")
+#
+# When a trained ``model.bin`` is absent we fall back to a trivial model so
+# that the service can still operate (albeit always predicting "not a
+# duplicate").  ``DummyClassifier`` is fitted on a single example so that
+# ``predict_proba`` is available without raising ``NotFittedError``.
+#
+_DEFAULT = DummyClassifier(strategy="constant", constant=0)
+_DEFAULT.fit(np.zeros((1, 10)), [0])  # feature_row outputs 10 features
 
 def load_model(path="model.bin"):
     if os.path.exists(path):
-        with open(path, "rb") as f: return pickle.load(f)
-    return DEFAULT
+        with open(path, "rb") as f:
+            return pickle.load(f)
+    return _DEFAULT
 
 def save_model(model, path="model.bin"):
     with open(path, "wb") as f: pickle.dump(model, f)
 
 def predict_proba(model, X):
-    return model.predict_proba(np.asarray(X))[:,1]
+    """Predict probability of the positive class.
+
+    Some fallback models (e.g. the ``DummyClassifier`` used when no trained
+    model is available) may only know about a single class.  In that case
+    scikit-learn returns a single probability column.  We treat this as a
+    zero probability for the positive class.
+    """
+    probs = model.predict_proba(np.asarray(X))
+    if probs.shape[1] == 1:
+        return np.zeros(probs.shape[0])
+    return probs[:, 1]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,22 @@
+import sys, pathlib, array
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.db import to_vec_array
+from app.config import Config
+
+
+def test_to_vec_array_length_ok():
+    vec = [0.0] * Config.VECTOR_DIM
+    arr = to_vec_array(vec)
+    assert isinstance(arr, array.array)
+    assert len(arr) == Config.VECTOR_DIM
+
+
+def test_to_vec_array_length_mismatch():
+    vec = [0.0] * (Config.VECTOR_DIM - 1)
+    with pytest.raises(ValueError):
+        to_vec_array(vec)
+

--- a/tests/test_model_store.py
+++ b/tests/test_model_store.py
@@ -1,0 +1,14 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.model_store import load_model, predict_proba
+
+
+def test_default_model_predicts_zero(tmp_path):
+    """When no saved model exists, predictions should return 0.0."""
+    model_path = tmp_path / "model.bin"
+    model = load_model(str(model_path))
+    proba = predict_proba(model, [[0] * 10])[0]
+    assert proba == 0.0
+


### PR DESCRIPTION
## Summary
- validate embedding vector length before binding to Oracle
- use fitted DummyClassifier as safe default model and handle single-class probability
- add tests for vector conversion and default model behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d2d4699883309283bd695f3af284