### PR TITLE
Refactor vector validation and model caching

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -3,8 +3,7 @@ from pydantic import BaseModel
 from app.deduper import check_duplicate
 from app.normalization import canonical_identity_text, norm_phone_e164, norm_email, norm_govid
 from app.embeddings import embed_identity
-from app.db import get_conn
-from app.config import Config
+from app.db import get_conn, to_vec_array
 
 app = FastAPI(title="Reduplicator (Oracle 23ai)")
 
@@ -59,7 +58,6 @@ def create_customer(cust: Customer):
             :identity_text, :identity_vec
         )
         """
-        import array
         bind = {
             "full_name": normed["full_name"],
             "dob": normed["dob"],
@@ -72,7 +70,7 @@ def create_customer(cust: Customer):
             "postal_code": normed["postal_code"],
             "country": normed["country"],
             "identity_text": ident,
-            "identity_vec": array.array('f', vec),
+            "identity_vec": to_vec_array(vec),
         }
 
         cur.execute(sql, bind)

--- a/app/model_store.py
+++ b/app/model_store.py
@@ -11,11 +11,18 @@ from sklearn.dummy import DummyClassifier
 _DEFAULT = DummyClassifier(strategy="constant", constant=0)
 _DEFAULT.fit(np.zeros((1, 10)), [0])  # feature_row outputs 10 features
 
+# Cache loaded models keyed by path to avoid repeated disk I/O
+_CACHE: dict[str, object] = {}
+
 def load_model(path="model.bin"):
+    if path in _CACHE:
+        return _CACHE[path]
     if os.path.exists(path):
         with open(path, "rb") as f:
-            return pickle.load(f)
-    return _DEFAULT
+            _CACHE[path] = pickle.load(f)
+    else:
+        _CACHE[path] = _DEFAULT
+    return _CACHE[path]
 
 def save_model(model, path="model.bin"):
     with open(path, "wb") as f: pickle.dump(model, f)

--- a/scripts/ingest_csv.py
+++ b/scripts/ingest_csv.py
@@ -1,10 +1,9 @@
 import csv
 import argparse
-import array
 
 from app.normalization import canonical_identity_text, norm_phone_e164, norm_email, norm_govid
 from app.embeddings import embed_identity
-from app.db import get_conn
+from app.db import get_conn, to_vec_array
 
 
 def ingest_csv(path: str):
@@ -41,7 +40,7 @@ def ingest_csv(path: str):
                 normed["addr_line"], normed["city"], normed["state"], normed["postal_code"], normed["country"]
             )
             vec = embed_identity(ident)
-            bind = normed | {"identity_text": ident, "identity_vec": array.array('f', vec)}
+            bind = normed | {"identity_text": ident, "identity_vec": to_vec_array(vec)}
             cur.execute(sql, bind)
         conn.commit()
 


### PR DESCRIPTION
## Summary
- Validate embedding length when inserting customers via API and CSV ingestion
- Cache loaded models to avoid redundant disk I/O

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d84902688330b7aef2091e9db643