### PR TITLE
Improve feature typing and database cursor safety

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -44,8 +44,7 @@ def create_customer(cust: Customer):
     )
     vec = embed_identity(ident)
 
-    with get_conn() as conn:
-        cur = conn.cursor()
+    with get_conn() as conn, conn.cursor() as cur:
         sql = """
         INSERT INTO customers(
             full_name, dob, phone_e164, email_norm, gov_id_norm,

--- a/app/db.py
+++ b/app/db.py
@@ -1,12 +1,18 @@
 import array
+from typing import Sequence
+
 import oracledb
+
 from .config import Config
 
-def get_conn():
+def get_conn() -> oracledb.Connection:
+    """Return a new Oracle database connection."""
     # Thin mode defaults; use thick if you want.
-    return oracledb.connect(user=Config.ORACLE_USER, password=Config.ORACLE_PASSWORD, dsn=Config.ORACLE_DSN)
+    return oracledb.connect(
+        user=Config.ORACLE_USER, password=Config.ORACLE_PASSWORD, dsn=Config.ORACLE_DSN
+    )
 
-def to_vec_array(vec_f32):
+def to_vec_array(vec_f32: Sequence[float]) -> array.array:
     """Convert an iterable of float32 values to :class:`array.array`.
 
     Oracle 23ai's driver can error (``DPY-3002``) when numpy arrays are
@@ -31,33 +37,39 @@ def to_vec_array(vec_f32):
     """
     if len(vec_f32) != Config.VECTOR_DIM:
         raise ValueError(f"expected vector of length {Config.VECTOR_DIM}")
-    return array.array('f', vec_f32)  # float32
+    return array.array("f", vec_f32)  # float32
 
-def topk_by_vector(conn, query_vec, k):
-    """
-    Insert into query_identity, ANN-ish search with VECTOR_DISTANCE, then delete.
-    Returns (customer_id, distance, lightweight fields).
+def topk_by_vector(
+    conn: oracledb.Connection, query_vec: Sequence[float], k: int
+) -> list[tuple]:
+    """Return the ``k`` nearest neighbours using Oracle's ``VECTOR_DISTANCE``.
+
+    The query vector is temporarily inserted into ``query_identity`` so that we
+    can leverage SQL for the similarity search.  The row is cleaned up
+    afterwards.
     """
     qarr = to_vec_array(query_vec)
-    cur = conn.cursor()
-    # Insert the query vector
-    cur.execute("INSERT INTO query_identity(qvec) VALUES (:1)", [qarr])
-    cur.execute("SELECT qid FROM query_identity ORDER BY qid DESC FETCH FIRST 1 ROWS ONLY")
-    qid = cur.fetchone()[0]
+    with conn.cursor() as cur:
+        # Insert the query vector
+        cur.execute("INSERT INTO query_identity(qvec) VALUES (:1)", [qarr])
+        cur.execute(
+            "SELECT qid FROM query_identity ORDER BY qid DESC FETCH FIRST 1 ROWS ONLY"
+        )
+        qid = cur.fetchone()[0]
 
-    sql = """
-    WITH q AS (SELECT qvec FROM query_identity WHERE qid = :qid)
-    SELECT c.customer_id,
-           VECTOR_DISTANCE(c.identity_vec, q.qvec) AS vdist,
-           c.full_name, c.dob, c.phone_e164, c.email_norm, c.gov_id_norm,
-           c.addr_line, c.city, c.state, c.postal_code
-    FROM customers c CROSS JOIN q
-    ORDER BY vdist
-    FETCH FIRST :k ROWS ONLY
-    """
-    cur.execute(sql, dict(qid=qid, k=k))
-    rows = cur.fetchall()
-    # Cleanup
-    cur.execute("DELETE FROM query_identity WHERE qid = :qid", dict(qid=qid))
-    conn.commit()
-    return rows
+        sql = """
+        WITH q AS (SELECT qvec FROM query_identity WHERE qid = :qid)
+        SELECT c.customer_id,
+               VECTOR_DISTANCE(c.identity_vec, q.qvec) AS vdist,
+               c.full_name, c.dob, c.phone_e164, c.email_norm, c.gov_id_norm,
+               c.addr_line, c.city, c.state, c.postal_code
+        FROM customers c CROSS JOIN q
+        ORDER BY vdist
+        FETCH FIRST :k ROWS ONLY
+        """
+        cur.execute(sql, dict(qid=qid, k=k))
+        rows = cur.fetchall()
+        # Cleanup
+        cur.execute("DELETE FROM query_identity WHERE qid = :qid", dict(qid=qid))
+        conn.commit()
+        return rows

--- a/app/features.py
+++ b/app/features.py
@@ -1,32 +1,41 @@
+from typing import Mapping
+
 from rapidfuzz.distance import JaroWinkler
 
 
-def jw(a, b):
+def jw(a: str | None, b: str | None) -> float:
+    """Return the normalised Jaro–Winkler similarity.
+
+    ``rapidfuzz`` offers a ``normalized_similarity`` helper that already
+    returns a value in the 0..1 range, so we use that instead of dividing the
+    ``similarity`` score by 100.  ``None`` and empty inputs simply produce a
+    score of ``0.0``.
+    """
     a = (a or "").lower().strip()
     b = (b or "").lower().strip()
     if not a or not b:
         return 0.0
-    return JaroWinkler.similarity(a, b) / 100.0
+    return JaroWinkler.normalized_similarity(a, b)
 
 
-def exact_match(a, b):
+def exact_match(a: str | None, b: str | None) -> float:
     """Return ``1.0`` when both values are non-empty and equal."""
     return 1.0 if a and b and a == b else 0.0
 
 
-def phone_match(a, b):
+def phone_match(a: str | None, b: str | None) -> float:
     return exact_match(a, b)
 
 
-def email_match(a, b):
+def email_match(a: str | None, b: str | None) -> float:
     return exact_match(a, b)
 
 
-def govid_match(a, b):
+def govid_match(a: str | None, b: str | None) -> float:
     return exact_match(a, b)
 
 
-def addr_overlap(a, b):
+def addr_overlap(a: str | None, b: str | None) -> float:
     """Simple Jaccard overlap of whitespace tokens for address lines."""
     set_a = set((a or "").lower().split())
     set_b = set((b or "").lower().split())
@@ -35,7 +44,7 @@ def addr_overlap(a, b):
     return len(set_a & set_b) / len(set_a | set_b)
 
 
-def pincode_match(a, b):
+def pincode_match(a: str | None, b: str | None) -> float:
     """Exact match gives 1.0; first five digits match gives 0.5."""
     a = (a or "").strip()
     b = (b or "").strip()
@@ -48,18 +57,24 @@ def pincode_match(a, b):
     return 0.0
 
 
-def dob_delta_days(a, b):
+def dob_delta_days(a: str | None, b: str | None) -> float:
     """Absolute difference in days between two ISO date strings."""
     if not a or not b:
         return 9999.0
     from datetime import date
-    def to_date(x):
+
+    def to_date(x: str | date) -> date:
         return x if isinstance(x, date) else date.fromisoformat(x)
+
     da = to_date(a)
     db = to_date(b)
     return abs((da - db).days)
 
-def feature_row(query, candidate, vdist):
+def feature_row(
+    query: Mapping[str, object],
+    candidate: Mapping[str, object],
+    vdist: float,
+) -> list[float]:
     """Generate feature vector for ranking."""
     vsim = 1.0 / (1.0 + vdist)  # distance to similarity-ish
     return [

--- a/app/normalization.py
+++ b/app/normalization.py
@@ -1,13 +1,20 @@
 import re
 
-def norm_name(s: str) -> str:
-    if not s: return ""
+
+def norm_name(s: str | None) -> str:
+    """Lowercase and strip non alphabetic characters.
+
+    ``None`` or empty inputs return an empty string.  Non-letter characters are
+    replaced with spaces and multiple spaces are collapsed.
+    """
+    if not s:
+        return ""
     s = s.lower()
     s = re.sub(r"[^a-z\s]", " ", s)
     s = re.sub(r"\s+", " ", s).strip()
     return s
 
-def norm_email(s: str) -> str:
+def norm_email(s: str | None) -> str:
     """Lowercase and apply provider-specific normalisation rules.
 
     For Gmail/Googlemail addresses, dots in the local part are ignored and
@@ -18,24 +25,42 @@ def norm_email(s: str) -> str:
     if not s:
         return ""
     local, sep, domain = s.partition("@")
-    if domain in ("gmail.com", "googlemail.com"):
+    if domain in {"gmail.com", "googlemail.com"}:
         local = local.split("+")[0]
         local = local.replace(".", "")
     return f"{local}{sep}{domain}"
 
-def norm_phone_e164(s: str) -> str:
-    # Expect inputs like "+91..." or "91..." etc; normalize to +CC format where you can.
+def norm_phone_e164(s: str | None) -> str:
+    """Return a best-effort E.164 formatted phone number.
+
+    Non-digit characters are stripped and a leading ``+`` is added when the
+    number appears to include a country code.  The implementation is intentionally
+    conservative – it does not attempt to guess country codes beyond recognising
+    ``91`` for India.
+    """
     s = (s or "").strip()
     s = re.sub(r"\D", "", s)
-    if s.startswith("91") and len(s) == 12: s = "+" + s
+    if s.startswith("91") and len(s) == 12:
+        s = "+" + s
     if not s.startswith("+") and len(s) >= 10:
-        s = "+{}".format(s)  # you may plug a smarter CC inference here
+        s = f"+{s}"  # you may plug a smarter CC inference here
     return s
 
-def norm_govid(s: str) -> str:
+def norm_govid(s: str | None) -> str:
     return (s or "").strip().upper()
 
-def canonical_identity_text(full_name, dob_iso, phone, email, govid, addr_line, city, state, postal_code, country):
+def canonical_identity_text(
+    full_name: str | None,
+    dob_iso: str | None,
+    phone: str | None,
+    email: str | None,
+    govid: str | None,
+    addr_line: str | None,
+    city: str | None,
+    state: str | None,
+    postal_code: str | None,
+    country: str | None,
+) -> str:
     parts = [
         f"name:{norm_name(full_name)}",
         f"dob:{(dob_iso or '').strip()}",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -3,6 +3,7 @@ import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from app.features import (
+    jw,
     pincode_match,
     dob_delta_days,
     feature_row,
@@ -29,6 +30,11 @@ def test_exact_match_wrappers():
     assert phone_match('123', '456') == 0.0
     assert email_match('a@b', 'a@b') == 1.0
     assert govid_match('PAN', 'PAN') == 1.0
+
+
+def test_jw_similarity():
+    assert jw('Alice', 'alice') == 1.0
+    assert jw(None, 'alice') == 0.0
 
 
 def test_feature_row_length_and_values():


### PR DESCRIPTION
## Summary
- use normalized Jaro-Winkler similarity and add type hints for feature helpers
- accept optional inputs in normalization utilities and document phone formatting
- handle Oracle cursors with context managers in db helpers and API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978ae4deb48330b38d402602d7a718