### PR TITLE
Add postal code normalization and PIN validation

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,7 +1,13 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 from app.deduper import check_duplicate
-from app.normalization import canonical_identity_text, norm_phone_e164, norm_email, norm_govid
+from app.normalization import (
+    canonical_identity_text,
+    norm_phone_e164,
+    norm_email,
+    norm_govid,
+    norm_postal_code,
+)
 from app.embeddings import embed_identity
 from app.db import get_conn, to_vec_array
 
@@ -35,7 +41,7 @@ def create_customer(cust: Customer):
         "addr_line": q.get("addr_line"),
         "city": q.get("city"),
         "state": q.get("state"),
-        "postal_code": q.get("postal_code"),
+        "postal_code": norm_postal_code(q.get("postal_code")),
         "country": q.get("country") or "IN",
     }
     ident = canonical_identity_text(

--- a/app/deduper.py
+++ b/app/deduper.py
@@ -1,5 +1,11 @@
 from .config import Config
-from .normalization import canonical_identity_text, norm_email, norm_phone_e164, norm_govid
+from .normalization import (
+    canonical_identity_text,
+    norm_email,
+    norm_phone_e164,
+    norm_govid,
+    norm_postal_code,
+)
 from .embeddings import embed_identity
 from .db import get_conn, topk_by_vector
 from .features import feature_row
@@ -15,7 +21,7 @@ def to_query_obj(payload):
         "addr_line": payload.get("addr_line"),
         "city": payload.get("city"),
         "state": payload.get("state"),
-        "postal_code": payload.get("postal_code"),
+        "postal_code": norm_postal_code(payload.get("postal_code")),
         "country": payload.get("country", "IN"),
     }
 
@@ -31,7 +37,7 @@ def candidate_dict(row):
         "addr_line": row[7],
         "city": row[8],
         "state": row[9],
-        "postal_code": row[10],
+        "postal_code": norm_postal_code(row[10]),
     }
 
 def check_duplicate(payload):

--- a/app/normalization.py
+++ b/app/normalization.py
@@ -49,6 +49,22 @@ def norm_phone_e164(s: str | None) -> str:
 def norm_govid(s: str | None) -> str:
     return (s or "").strip().upper()
 
+
+_PIN_RE = re.compile(r"^[1-9]\d{5}$")
+
+
+def norm_postal_code(s: str | None) -> str:
+    """Return a 6 digit Indian PIN code or ``""`` when invalid.
+
+    Whitespace is stripped and the code must match the ``XXNNNN`` format
+    (first digit non-zero followed by five digits).  Inputs not meeting these
+    criteria are treated as missing.
+    """
+    s = (s or "").strip().replace(" ", "")
+    if not s:
+        return ""
+    return s if _PIN_RE.fullmatch(s) else ""
+
 def canonical_identity_text(
     full_name: str | None,
     dob_iso: str | None,
@@ -70,7 +86,7 @@ def canonical_identity_text(
         f"addr:{(addr_line or '').lower()}",
         f"city:{(city or '').lower()}",
         f"state:{(state or '').lower()}",
-        f"pc:{(postal_code or '').lower()}",
+        f"pc:{norm_postal_code(postal_code)}",
         f"ctry:{(country or '').upper()}",
     ]
     return " | ".join(parts)

--- a/scripts/ingest_csv.py
+++ b/scripts/ingest_csv.py
@@ -1,7 +1,13 @@
 import csv
 import argparse
 
-from app.normalization import canonical_identity_text, norm_phone_e164, norm_email, norm_govid
+from app.normalization import (
+    canonical_identity_text,
+    norm_phone_e164,
+    norm_email,
+    norm_govid,
+    norm_postal_code,
+)
 from app.embeddings import embed_identity
 from app.db import get_conn, to_vec_array
 
@@ -32,7 +38,7 @@ def ingest_csv(path: str):
                 "addr_line": row.get("addr_line"),
                 "city": row.get("city"),
                 "state": row.get("state"),
-                "postal_code": row.get("postal_code"),
+                "postal_code": norm_postal_code(row.get("postal_code")),
                 "country": row.get("country") or "IN",
             }
             ident = canonical_identity_text(

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -2,7 +2,7 @@ import sys, pathlib
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from app.normalization import norm_email
+from app.normalization import norm_email, norm_postal_code, canonical_identity_text
 
 
 def test_norm_email_gmail_plus_dot():
@@ -11,3 +11,16 @@ def test_norm_email_gmail_plus_dot():
 
 def test_norm_email_other_provider():
     assert norm_email('User+spam@example.com') == 'user+spam@example.com'
+
+
+def test_norm_postal_code_validation():
+    assert norm_postal_code('560001') == '560001'
+    assert norm_postal_code('560 001') == '560001'
+    assert norm_postal_code('056000') == ''
+    assert norm_postal_code('56000A') == ''
+
+
+def test_canonical_identity_text_normalises_postal_code():
+    t1 = canonical_identity_text('Alice', None, None, None, None, None, None, None, '560 001', 'IN')
+    t2 = canonical_identity_text('Alice', None, None, None, None, None, None, None, '560001', 'IN')
+    assert t1 == t2

--- a/training/train_ranker.py
+++ b/training/train_ranker.py
@@ -4,7 +4,7 @@ from sklearn.linear_model import LogisticRegression
 from app.features import feature_row
 from app.db import get_conn
 from app.model_store import save_model
-from app.normalization import canonical_identity_text
+from app.normalization import canonical_identity_text, norm_postal_code
 from app.embeddings import embed_identity
 from app.deduper import candidate_dict
 from app.db import to_vec_array
@@ -44,7 +44,7 @@ def main(pairs_csv="labeled_pairs.csv"):
                 addr_line=r.get("query_addr"),
                 city=r.get("query_city"),
                 state=r.get("query_state"),
-                postal_code=r.get("query_pc"),
+                postal_code=norm_postal_code(r.get("query_pc")),
                 country=r.get("query_ctry"),
             )
             ident = canonical_identity_text(


### PR DESCRIPTION
## Summary
- add `norm_postal_code` helper to validate and standardise Indian PIN codes
- integrate postal code normalization across duplicate check, API, ingestion, and training utilities
- test canonical identity and postal code normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a8becfec8330aefa0ae263b15571