### PR TITLE
feat: add Oracle thick client init

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,9 +4,14 @@ import os
 load_dotenv()
 
 class Config:
-    ORACLE_DSN = os.getenv("ORACLE_DSN", "localhost/XEPDB1")
-    ORACLE_USER = os.getenv("ORACLE_USER", "users")
-    ORACLE_PASSWORD = os.getenv("ORACLE_PASSWORD", "oracle")
+    """Application configuration with environment overrides."""
+
+    # Default Oracle connection details for the 23ai instance. Environment
+    # variables (ORACLE_DSN, ORACLE_USER, ORACLE_PASSWORD) still take
+    # precedence over these values when set.
+    ORACLE_DSN = os.getenv("ORACLE_DSN", "localhost:1521/FREEPDB1")
+    ORACLE_USER = os.getenv("ORACLE_USER", "system")  # or face_app
+    ORACLE_PASSWORD = os.getenv("ORACLE_PASSWORD", "1123")  # or face_pass
     EMBED_MODEL = os.getenv("EMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
     TOPK = int(os.getenv("TOPK", "200"))
     THRESHOLD = float(os.getenv("THRESHOLD", "0.82"))

--- a/app/db.py
+++ b/app/db.py
@@ -4,6 +4,18 @@ import threading
 
 import oracledb
 
+# Attempt to initialize the Oracle client in thick mode if available.  If the
+# specified client libraries are not present or the initialization fails for
+# any reason, we fall back to the default thin mode.  This must happen before
+# any connections or pools are created.
+try:  # pragma: no cover - depends on client availability at runtime
+    oracledb.init_oracle_client(
+        lib_dir=r"C:\Users\Agam\Downloads\intern\pathinfotech\face\oracle23ai\dbhomeFree\bin"
+    )
+    print("Thick mode enabled")
+except Exception:  # pragma: no cover - executed when thick mode fails
+    print("Falling back to thin mode")
+
 from .config import Config
 
 _pool = None


### PR DESCRIPTION
## Summary
- init Oracle thick client with fallback to thin mode
- update default Oracle DSN and credentials

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c3205f38483309b921e48c791b566