### PR TITLE
Align API with frontend field names

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,3 +21,50 @@ def test_train_endpoint(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()["status"] == "trained"
     assert called["csv"] == "foo.csv"
+
+
+def test_dedupe_field_aliases(monkeypatch):
+    sample = {
+        "customer_id": 1,
+        "vdist": 0.12,
+        "full_name": "John Doe",
+        "dob": "1980-01-01",
+        "phone_e164": "+12025550123",
+        "email_norm": "john@example.com",
+        "gov_id_norm": "ID123",
+        "addr_line": "123 Street",
+        "city": "Metropolis",
+        "state": "NY",
+        "postal_code": "123456",
+        "score": 0.95,
+    }
+
+    def fake_check(payload):
+        return {
+            "is_duplicate": True,
+            "score": 0.95,
+            "best_match": sample,
+            "candidates": [sample],
+        }
+
+    monkeypatch.setattr(main, "check_duplicate", fake_check)
+
+    payload = {
+        "full_name": "Jane",
+        "date_of_birth": "1985-05-05",
+        "phone": "+1987654321",
+        "email": "jane@example.com",
+        "government_id": "ID999",
+        "address_line": "321 Ave",
+        "city": "Metropolis",
+        "state": "NY",
+        "postal_code": "654321",
+        "country": "IN",
+    }
+
+    resp = client.post("/dedupe/check", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["threshold"] == main.Config.THRESHOLD
+    assert data["best_match"]["name"] == "John Doe"
+    assert data["best_match"]["vector_distance"] == 0.12


### PR DESCRIPTION
## Summary
- Map frontend field names to backend models using Pydantic aliases
- Expose dedupe check results with frontend-friendly keys and threshold
- Add regression test for alias handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3a60e2388330b5b4d556a89872e5