### PR TITLE
Connect frontend to backend data

### DIFF
--- a/frontend/components/dashboard.tsx
+++ b/frontend/components/dashboard.tsx
@@ -6,8 +6,23 @@ import { Button } from "@/components/ui/button"
 import { StatusCard } from "./status-card"
 import { AnimatedContainer } from "./animated-container"
 import { LoadingSpinner } from "./loading-spinner"
-import { checkHealth, checkReadiness, getMetricsUrl, type HealthStatus } from "@/lib/api"
+import {
+  checkHealth,
+  checkReadiness,
+  getMetricsUrl,
+  getStats,
+  type HealthStatus,
+} from "@/lib/api"
 import { ExternalLink, RefreshCw, Activity, Users, AlertTriangle, TrendingUp, Building2 } from "lucide-react"
+
+interface LoanMetrics {
+  totalApplicants: number
+  todayApplicants: number
+  duplicateAlerts: number
+  highRiskDuplicates: number
+  processingRate: number
+  lastUpdated: string
+}
 
 export function Dashboard() {
   const [healthStatus, setHealthStatus] = useState<HealthStatus>({
@@ -20,21 +35,33 @@ export function Dashboard() {
   })
   const [isLoading, setIsLoading] = useState(false)
 
-  const [loanMetrics] = useState({
-    totalApplicants: 1247,
-    todayApplicants: 23,
-    duplicateAlerts: 8,
-    highRiskDuplicates: 3,
-    processingRate: 94.2,
-    lastUpdated: new Date().toLocaleString(),
+  const [loanMetrics, setLoanMetrics] = useState<LoanMetrics>({
+    totalApplicants: 0,
+    todayApplicants: 0,
+    duplicateAlerts: 0,
+    highRiskDuplicates: 0,
+    processingRate: 0,
+    lastUpdated: "",
   })
 
   const checkStatuses = async () => {
     setIsLoading(true)
     try {
-      const [health, readiness] = await Promise.all([checkHealth(), checkReadiness()])
+      const [health, readiness, stats] = await Promise.all([
+        checkHealth(),
+        checkReadiness(),
+        getStats(),
+      ])
       setHealthStatus(health)
       setReadinessStatus(readiness)
+      setLoanMetrics({
+        totalApplicants: stats.total_applicants,
+        todayApplicants: stats.today_applicants,
+        duplicateAlerts: stats.duplicate_alerts,
+        highRiskDuplicates: stats.high_risk_duplicates,
+        processingRate: stats.processing_rate,
+        lastUpdated: new Date().toLocaleString(),
+      })
     } catch (error) {
       console.error("Error checking statuses:", error)
     } finally {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -68,6 +68,27 @@ export async function checkReadiness(): Promise<HealthStatus> {
   }
 }
 
+export interface Stats {
+  total_applicants: number
+  today_applicants: number
+  duplicate_alerts: number
+  high_risk_duplicates: number
+  processing_rate: number
+}
+
+export async function getStats(): Promise<Stats> {
+  const response = await fetch(`${API_BASE_URL}/stats`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
+  return response.json()
+}
+
 export function getMetricsUrl(): string {
   return `${API_BASE_URL}/metrics`
 }

--- a/frontend/lib/loan-duplicate-api.ts
+++ b/frontend/lib/loan-duplicate-api.ts
@@ -87,49 +87,12 @@ export const checkLoanDuplicate = async (formData: LoanDuplicateCheckRequest): P
       throw new Error(errorData.detail || `HTTP error! status: ${response.status}`)
     }
 
-    const data = await response.json()
-
-    // Enhance response with mock loan data for demonstration
-    const enhancedData: LoanDuplicateCheckResponse = {
-      ...data,
-      candidates:
-        data.candidates?.map((candidate: any) => ({
-          ...candidate,
-          existing_account_id: Math.random() > 0.5 ? `ACC${Math.floor(Math.random() * 100000)}` : undefined,
-          existing_loan_ids: Math.random() > 0.7 ? [`LN${Math.floor(Math.random() * 100000)}`] : [],
-          loan_history:
-            Math.random() > 0.6
-              ? [
-                  {
-                    loan_type: ["Personal Loan", "Home Loan", "Car Loan"][Math.floor(Math.random() * 3)],
-                    amount: Math.floor(Math.random() * 1000000) + 100000,
-                    status: ["Active", "Closed", "Defaulted"][Math.floor(Math.random() * 3)],
-                    date: new Date(Date.now() - Math.random() * 365 * 24 * 60 * 60 * 1000).toISOString().split("T")[0],
-                  },
-                ]
-              : [],
-        })) || [],
-      best_match: data.best_match
-        ? {
-            ...data.best_match,
-            existing_account_id: `ACC${Math.floor(Math.random() * 100000)}`,
-            existing_loan_ids: [`LN${Math.floor(Math.random() * 100000)}`],
-            loan_history: [
-              {
-                loan_type: "Home Loan",
-                amount: 2500000,
-                status: "Active",
-                date: "2023-06-15",
-              },
-            ],
-          }
-        : null,
-    }
+    const data: LoanDuplicateCheckResponse = await response.json()
 
     return {
       success: true,
       message: "Duplicate check completed successfully",
-      data: enhancedData,
+      data,
     }
   } catch (error) {
     console.error("Error checking for duplicates:", error)


### PR DESCRIPTION
## Summary
- expose `/stats` API to provide applicant counts and duplicate metrics
- fetch stats in dashboard instead of using hard-coded numbers
- remove mock data from loan duplicate check and return backend results
- add frontend helper for new stats endpoint

## Testing
- `pytest`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c4c60dd848330944e2075d16d8b7f