### PR TITLE
Pin numpy and pandas versions for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ been seen in our system?" and is tuned for KYC/loan workflows.
 
    ```bash
    python -m venv .venv && . .venv/bin/activate
-   pip install -r requirements.txt
+   pip install -r requirements.txt  # installs numpy<2 for compatibility
    uvicorn app.api.main:app --host 0.0.0.0 --port 8000
    ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ python-dotenv
 oracledb
 rapidfuzz
 scikit-learn
-numpy
-pandas
+numpy>=1.26,<2
+pandas<2.3
 sentence-transformers
 prometheus-client
 httpx


### PR DESCRIPTION
## Summary
- pin numpy to <2 and cap pandas to <2.3 to avoid runtime errors with modules built for numpy 1.x
- document numpy compatibility note in backend installation instructions

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c74228d3c8330836fa6973735c87c