### PR TITLE
Fix hydration mismatch and improve training API

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, Response
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field, ConfigDict
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
@@ -16,6 +17,13 @@ from app.config import Config
 from training.train_ranker import main as train_ranker
 
 app = FastAPI(title="Reduplicator (Oracle 23ai)")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 class Customer(BaseModel):
     full_name: str
@@ -103,8 +111,8 @@ def stats():
 
 @app.post("/train")
 def train(req: TrainRequest):
-    train_ranker(req.data_path)
-    return {"status": "trained"}
+    result = train_ranker(req.data_path)
+    return result
 
 @app.post("/dedupe/check")
 def dedupe_check(cust: Customer):

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -4,11 +4,18 @@ from sentence_transformers import SentenceTransformer
 
 from .config import Config
 
+try:  # Prefer DirectML for GPU acceleration when available
+    import torch_directml
+
+    _DEVICE = torch_directml.device()
+except Exception:  # pragma: no cover - fallback to CPU if DirectML unavailable
+    _DEVICE = "cpu"
+
 
 @lru_cache()
 def get_model() -> SentenceTransformer:
     """Return a cached ``SentenceTransformer`` instance."""
-    return SentenceTransformer(Config.EMBED_MODEL)
+    return SentenceTransformer(Config.EMBED_MODEL, device=_DEVICE)
 
 def embed_identity(text: str):
     """

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -37,7 +37,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${inter.variable} ${montserrat.variable} ${openSans.variable} antialiased`}>
-      <body className="font-open-sans transition-colors duration-300">
+      <body
+        className="font-open-sans transition-colors duration-300"
+        suppressHydrationWarning
+      >
         {/* Wrapped children in ThemeProvider */}
         <ThemeProvider>{children}</ThemeProvider>
       </body>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,11 +18,12 @@ def test_train_endpoint(monkeypatch):
 
     def fake_train(path):
         called["path"] = path
+        return {"success": True, "message": "ok"}
 
     monkeypatch.setattr(main, "train_ranker", fake_train)
     resp = client.post("/train", json={"csv_path": "foo.csv"})
     assert resp.status_code == 200
-    assert resp.json()["status"] == "trained"
+    assert resp.json()["success"] is True
     assert called["path"] == "foo.csv"
 
 


### PR DESCRIPTION
## Summary
- prevent Next.js hydration warnings by suppressing body class mismatch
- allow frontend access with permissive CORS and richer `/train` results
- enable DirectML for embeddings and return training metrics

## Testing
- `pytest`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689c7778fac08330b46eb92068079e88