### PR TITLE
Handle missing training data for training endpoint

### DIFF
--- a/tests/test_train_ranker.py
+++ b/tests/test_train_ranker.py
@@ -1,0 +1,13 @@
+import pathlib
+
+from training import train_ranker
+
+
+def test_missing_training_data(tmp_path: pathlib.Path):
+    """Ensure a helpful response when the training data file is absent."""
+
+    missing = tmp_path / "does-not-exist.csv"
+    result = train_ranker.main(str(missing))
+    assert result["success"] is False
+    assert "Training data not found" in result["message"]
+


### PR DESCRIPTION
## Summary
- guard against missing training data in `train_ranker` so the UI gets a clear error instead of failing silently
- add regression test covering missing training data case

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7001c47d08330aa8539d9a00e0f3a