### PR TITLE
fix: trigger training on button click

### DIFF
--- a/frontend/components/train-model-form.tsx
+++ b/frontend/components/train-model-form.tsx
@@ -57,8 +57,10 @@ export function TrainModelForm() {
     return interval
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = async (
+    e?: React.FormEvent | React.MouseEvent
+  ) => {
+    e?.preventDefault()
 
     if (!dataPath.trim()) {
       toast({
@@ -190,7 +192,8 @@ export function TrainModelForm() {
             {/* Submit Button */}
             <div className="flex gap-4">
               <Button
-                type="submit"
+                type="button"
+                onClick={handleSubmit}
                 disabled={trainingStatus.isTraining}
                 className="bg-secondary text-secondary-foreground hover:bg-secondary/90"
               >


### PR DESCRIPTION
## Summary
- ensure training form handleSubmit covers both form submit and button click events
- trigger model training directly from Start Training button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7001c47d08330aa8539d9a00e0f3a