### PR TITLE
Handle training errors to keep CORS headers intact

### DIFF
--- a/app/api/main.py
+++ b/app/api/main.py
@@ -111,7 +111,11 @@ def stats():
 
 @app.post("/train")
 def train(req: TrainRequest):
-    result = train_ranker(req.data_path)
+    """Trigger model training and handle unexpected errors gracefully."""
+    try:
+        result = train_ranker(req.data_path)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail=f"Training failed: {exc}") from exc
     return result
 
 @app.post("/dedupe/check")

--- a/tests/test_api_train.py
+++ b/tests/test_api_train.py
@@ -1,0 +1,24 @@
+import pathlib
+
+from fastapi.testclient import TestClient
+
+from app.api.main import app
+
+
+def test_train_endpoint_cors_and_missing_file(tmp_path: pathlib.Path):
+    """Train endpoint should return a helpful error and CORS headers."""
+
+    client = TestClient(app)
+    missing = tmp_path / "missing.csv"
+    resp = client.post(
+        "/train",
+        json={"csv_path": str(missing)},
+        headers={"Origin": "http://example.com"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "*"
+    body = resp.json()
+    assert body["success"] is False
+    assert "Training data not found" in body["message"]
+


### PR DESCRIPTION
## Summary
- add defensive error handling to `/train` endpoint so unexpected failures still return CORS headers
- add regression test ensuring CORS headers are present when training data is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a703edcbb083308732f29e1ab5b021