### PR TITLE
Add prepare_pairs script to sample training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,16 @@ been seen in our system?" and is tuned for KYC/loan workflows.
    python scripts/ingest_csv.py customers.csv
    ```
 
-5. **Check a duplicate** via API or the web UI:
+5. **Generate training pairs** from the ingested customers:
+
+   ```bash
+   python training/prepare_pairs.py --output labeled_pairs.csv
+   ```
+
+   The script samples duplicate and hard-negative pairs and writes them to
+   ``labeled_pairs.csv`` (or a Parquet file if the extension is ``.parquet``).
+
+6. **Check a duplicate** via API or the web UI:
 
    ```bash
    curl -X POST http://localhost:8000/dedupe/check \
@@ -61,7 +70,7 @@ been seen in our system?" and is tuned for KYC/loan workflows.
         -d '{"full_name":"Rohan K.","dob":"1995-11-20","phone":"+91-9876543210"}'
    ```
 
-6. **Train the ranker** once you have labeled pairs:
+7. **Train the ranker** once you have labeled pairs:
 
    ```bash
    python training/train_ranker.py path/to/labeled_pairs

--- a/training/prepare_pairs.py
+++ b/training/prepare_pairs.py
@@ -1,8 +1,144 @@
-"""
-Create a CSV with columns:
-query_full_name,query_dob,query_phone,query_email,query_gov_id,query_addr,query_city,query_state,query_pc,query_ctry,
-cand_customer_id,label
+"""Utilities for creating a labelled training set for the ranker.
 
-Populate this by sampling real queries and the customer_id of either the true match (label=1)
-or a hard negative (label=0).
+The ranker in :mod:`training.train_ranker` expects a table with the
+following columns:
+
+``query_full_name, query_dob, query_phone, query_email, query_gov_id,
+query_addr, query_city, query_state, query_pc, query_ctry,
+cand_customer_id, label``
+
+``prepare_pairs.py`` samples rows from the ``USERS.CUSTOMERS`` table and
+emits pairs of a *query* (the fields above prefixed with ``query_``) and a
+candidate ``customer_id``.  ``label`` is ``1`` when the candidate is a true
+duplicate of the query row and ``0`` for hard negatives.
+
+The script writes the result to ``labeled_pairs.csv`` by default but will
+also emit Parquet when the output path ends with ``.parquet``.
 """
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+from app.db import get_conn, topk_by_vector
+from app.normalization import canonical_identity_text
+from app.embeddings import embed_identity
+
+
+def _row_to_query(row: pd.Series) -> dict[str, object]:
+    """Return a dictionary of query fields from a customer row."""
+
+    dob = row.get("dob")
+    if pd.notna(dob):
+        dob = str(pd.to_datetime(dob).date())
+
+    return {
+        "query_full_name": row.get("full_name"),
+        "query_dob": dob,
+        "query_phone": row.get("phone_e164"),
+        "query_email": row.get("email_norm"),
+        "query_gov_id": row.get("gov_id_norm"),
+        "query_addr": row.get("addr_line"),
+        "query_city": row.get("city"),
+        "query_state": row.get("state"),
+        "query_pc": row.get("postal_code"),
+        "query_ctry": row.get("country"),
+    }
+
+
+def _query_vector(row: pd.Series) -> Sequence[float]:
+    """Compute the embedding for ``row`` used to mine hard negatives."""
+
+    ident = canonical_identity_text(
+        row.get("full_name"),
+        row.get("dob"),
+        row.get("phone_e164"),
+        row.get("email_norm"),
+        row.get("gov_id_norm"),
+        row.get("addr_line"),
+        row.get("city"),
+        row.get("state"),
+        row.get("postal_code"),
+        row.get("country"),
+    )
+    return embed_identity(ident)
+
+
+def _hard_negative(
+    conn, qvec: Sequence[float], exclude_ids: Iterable[int], k: int = 20
+) -> int | None:
+    """Return the ``customer_id`` of a near neighbour not in ``exclude_ids``."""
+
+    rows = topk_by_vector(conn, qvec, k)
+    for row in rows:
+        cid = int(row[0])
+        if cid not in exclude_ids:
+            return cid
+    return None
+
+
+def main(output_path: str = "labeled_pairs.csv") -> None:
+    """Sample query/candidate pairs from the customer table.
+
+    The function identifies duplicate clusters using ``identity_text``.  For
+    each row in a cluster it emits one or more positive examples (other rows
+    in the cluster) and a hard negative mined from the vector index.
+    """
+
+    with get_conn() as conn:
+        sql = """
+            SELECT customer_id, full_name, dob, phone_e164, email_norm,
+                   gov_id_norm, addr_line, city, state, postal_code,
+                   country, identity_text
+            FROM USERS.CUSTOMERS
+        """
+        df = pd.read_sql(sql, conn)
+
+        pairs: list[dict[str, object]] = []
+        for _, group in df.groupby("identity_text"):
+            if len(group) <= 1:
+                continue
+
+            ids = set(int(x) for x in group["customer_id"].tolist())
+            for _, q in group.iterrows():
+                q_fields = _row_to_query(q)
+
+                # Positive pairs for other members of the cluster
+                others = group[group["customer_id"] != q["customer_id"]]
+                for _, cand in others.iterrows():
+                    pairs.append(
+                        q_fields
+                        | {
+                            "cand_customer_id": int(cand["customer_id"]),
+                            "label": 1,
+                        }
+                    )
+
+                # Hard negative
+                qvec = _query_vector(q)
+                neg_id = _hard_negative(conn, qvec, ids)
+                if neg_id is not None:
+                    pairs.append(q_fields | {"cand_customer_id": neg_id, "label": 0})
+
+        out_df = pd.DataFrame(pairs)
+        if output_path.lower().endswith(('.parquet', '.pq')):
+            out_df.to_parquet(output_path, index=False)
+        else:
+            out_df.to_csv(output_path, index=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Sample query/candidate pairs for ranker training"
+    )
+    parser.add_argument(
+        "--output",
+        default="labeled_pairs.csv",
+        help="Path to CSV or Parquet file to write",
+    )
+    args = parser.parse_args()
+    main(args.output)
+


### PR DESCRIPTION
## Summary
- implement `training/prepare_pairs.py` to sample duplicate and hard-negative pairs from ingested customers and write them to CSV or Parquet
- document how to generate `labeled_pairs.csv` before invoking model training

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a708754ed4833093f7bbf94f7cade0