### PR TITLE
Fix training scripts import path

### DIFF
--- a/training/prepare_pairs.py
+++ b/training/prepare_pairs.py
@@ -19,9 +19,17 @@ also emit Parquet when the output path ends with ``.parquet``.
 from __future__ import annotations
 
 import argparse
+import sys
+from pathlib import Path
 from typing import Iterable, Sequence
 
 import pandas as pd
+
+# Allow running this script directly without installing the package by adding the
+# repository root to ``sys.path`` when ``app`` cannot be imported normally.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
 from app.db import get_conn, topk_by_vector
 from app.normalization import canonical_identity_text

--- a/training/train_ranker.py
+++ b/training/train_ranker.py
@@ -1,8 +1,18 @@
 import time
 import uuid
 import os
+import sys
+from pathlib import Path
+
 import numpy as np
 from sklearn.linear_model import LogisticRegression
+
+# Ensure the repository root is on ``sys.path`` so that the ``app`` package can
+# be imported when running this script directly (``python training/train_ranker.py``).
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
 from app.features import feature_row
 from app.db import get_conn
 from app.model_store import save_model


### PR DESCRIPTION
## Summary
- allow running training/prepare_pairs.py directly by appending repo root to PYTHONPATH
- apply same fix to training/train_ranker.py

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a70c3cd33c8330b5991b2d84eddbad