### PR TITLE
Normalize column names in prepare_pairs for Oracle compatibility

### DIFF
--- a/tests/test_prepare_pairs.py
+++ b/tests/test_prepare_pairs.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from pathlib import Path
+from training import prepare_pairs
+
+
+class DummyConn:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_handles_uppercase_columns(tmp_path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "CUSTOMER_ID": [1, 2],
+            "IDENTITY_TEXT": ["a", "a"],
+        }
+    )
+
+    monkeypatch.setattr(prepare_pairs, "get_conn", lambda: DummyConn())
+    monkeypatch.setattr(pd, "read_sql", lambda sql, conn: df)
+    monkeypatch.setattr(prepare_pairs, "_row_to_query", lambda row: {})
+    monkeypatch.setattr(prepare_pairs, "_query_vector", lambda row: [0.0])
+    monkeypatch.setattr(
+        prepare_pairs,
+        "_hard_negative",
+        lambda conn, qvec, exclude_ids, k=20: None,
+    )
+
+    out = tmp_path / "pairs.csv"
+    prepare_pairs.main(str(out))
+    result = pd.read_csv(out)
+    assert set(result["cand_customer_id"]) == {1, 2}
+    assert (result["label"] == 1).all()

--- a/training/prepare_pairs.py
+++ b/training/prepare_pairs.py
@@ -104,6 +104,12 @@ def main(output_path: str = "labeled_pairs.csv") -> None:
             FROM USERS.CUSTOMERS
         """
         df = pd.read_sql(sql, conn)
+        # Oracle returns column names in uppercase by default which causes key
+        # lookups like ``row["customer_id"]`` to fail.  Normalize the columns to
+        # lowercase so the rest of the code can consistently reference them.
+        df.columns = df.columns.str.lower()
+        if "customer_id" not in df.columns:
+            raise KeyError("customer_id column is missing from USERS.CUSTOMERS")
         if "identity_text" not in df.columns:
             def _ident_text(row: pd.Series) -> str:
                 dob = row.get("dob")


### PR DESCRIPTION
## Summary
- Normalize dataframe columns to lowercase in `prepare_pairs` to handle Oracle's uppercase column names
- Add regression test ensuring `prepare_pairs` works with uppercase column names

## Testing
- `pytest -q`
- `python training/prepare_pairs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a73961bf80833096cda2b2405c1d03