### PR TITLE
Ensure CLI uses tqdm progress bar

### DIFF
--- a/training/prepare_pairs.py
+++ b/training/prepare_pairs.py
@@ -27,7 +27,7 @@ import random
 from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
-from tqdm.auto import tqdm
+from tqdm import tqdm
 
 # Allow running this script directly without installing the package by adding the
 # repository root to ``sys.path`` when ``app`` cannot be imported normally.


### PR DESCRIPTION
## Summary
- use the standard `tqdm` import in `prepare_pairs` to guarantee progress display in console environments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a793a63f6c833092786a8f706c7e4e