### PR TITLE
feat: add heuristic fallback classifier

### DIFF
--- a/app/model_store.py
+++ b/app/model_store.py
@@ -1,15 +1,78 @@
 import os
 import pickle
 import numpy as np
-from sklearn.dummy import DummyClassifier
+
+
+class RuleBasedClassifier:
+    """Light-weight classifier used when no trained model is available.
+
+    The classifier implements a small set of heuristic rules that look at the
+    feature vector produced by :func:`app.features.feature_row` and assigns a
+    probability for the *duplicate* class.  It does not require any training
+    and therefore provides consistent behaviour out of the box.
+
+    The feature order is expected to be::
+
+        [vdist_sim, name_sim, phone_match, email_match, govid_match,
+         addr_overlap, city_sim, state_sim, pincode_match, dob_delta]
+
+    The heuristics favour hard identifiers such as government ID, phone number
+    and email.  Softer signals like name or address contribute small amounts to
+    the final score.  The result is a number in the ``0..1`` range similar to a
+    probability.
+    """
+
+    def fit(self, X=None, y=None):  # scikit-learn compatibility
+        return self
+
+    def predict_proba(self, X):
+        X = np.asarray(X)
+        probs = np.zeros((X.shape[0], 2), dtype=float)
+        for i, row in enumerate(X):
+            (
+                vsim,
+                name_sim,
+                phone_match,
+                email_match,
+                govid_match,
+                addr_overlap,
+                city_sim,
+                state_sim,
+                pincode_match,
+                dob_delta,
+            ) = row
+
+            # Strong identifiers dominate the score
+            if govid_match >= 1.0:
+                score = 0.99
+            else:
+                score = 0.0
+                score += 0.4 * phone_match
+                score += 0.4 * email_match
+                score += 0.1 * vsim
+                score += 0.1 * name_sim
+                score += 0.05 * addr_overlap
+                score += 0.05 * city_sim
+                score += 0.03 * state_sim
+                score += 0.05 * pincode_match
+                if (phone_match or email_match or name_sim > 0.0) and dob_delta < 365:
+                    if dob_delta < 30:
+                        score += 0.1
+                    else:
+                        score += 0.05
+                score = min(score, 0.99)
+
+            probs[i, 0] = 1.0 - score
+            probs[i, 1] = score
+        return probs
 
 #
-# When a trained ``model.bin`` is absent we fall back to a trivial model so
-# that the service can still operate (albeit always predicting "not a
-# duplicate").  ``DummyClassifier`` is fitted on a single example so that
-# ``predict_proba`` is available without raising ``NotFittedError``.
+# When a trained ``model.bin`` is absent we fall back to the
+# :class:`RuleBasedClassifier` defined above.  It requires no training but we
+# still call ``fit`` to mirror the behaviour of scikit-learn estimators and to
+# document that the feature vector has 10 entries.
 #
-_DEFAULT = DummyClassifier(strategy="constant", constant=0)
+_DEFAULT = RuleBasedClassifier()
 _DEFAULT.fit(np.zeros((1, 10)), [0])  # feature_row outputs 10 features
 
 # Cache loaded models keyed by path to avoid repeated disk I/O

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -1,0 +1,20 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.model_store import load_model, predict_proba
+
+
+def test_rule_based_model_high_score(tmp_path):
+    model = load_model(path=str(tmp_path / "missing.bin"))
+    feats = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0]
+    prob = predict_proba(model, [feats])[0]
+    assert prob > 0.95
+
+
+def test_rule_based_model_low_score(tmp_path):
+    model = load_model(path=str(tmp_path / "missing2.bin"))
+    feats = [0.0] * 9 + [9999.0]
+    prob = predict_proba(model, [feats])[0]
+    assert prob == 0.0


### PR DESCRIPTION
## Summary
- add rule-based duplicate classifier as a reliable fallback
- include tests for heuristic classifier behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a962d8208330b46a026611fadf51